### PR TITLE
fix: corrige l'erreur pour les communes sans surface forestière

### DIFF
--- a/calculations/flux/index.js
+++ b/calculations/flux/index.js
@@ -250,8 +250,10 @@ function fluxSummary (allFluxes, options) {
   // update change flag for forests based on if the area used in biomass growth
   // calculations is defined by the user.
   const biomassGrowthAreaModified = biomassSummary.some((subtype) => subtype.areaModified)
-  summary.forêts.areaModified = summary.forêts.areaModified || biomassGrowthAreaModified
-  summary.forêts.hasModifications = summary.forêts.hasModifications || biomassGrowthAreaModified
+  if (summary.forêts) {
+    summary.forêts.areaModified = summary.forêts.areaModified || biomassGrowthAreaModified
+    summary.forêts.hasModifications = summary.forêts.hasModifications || biomassGrowthAreaModified
+  }
   return { summary, biomassSummary, fluxCo2eByGroundType, woodSummary, total }
 }
 


### PR DESCRIPTION
## Summary
- Corrige le bug #128 : les communes sans surface forestière (16 communes signalées dans les départements 91 et 94) provoquaient un crash avec le message "Une erreur est survenue"
- La cause : `summary.forêts` n'est pas initialisé quand aucun flux forestier n'existe pour une commune, mais le code y accédait sans vérification (introduit avec le module de comparaison IGN en 77c179e)
- Ajout d'un guard `if (summary.forêts)` avant d'accéder à ses propriétés

Fixes #128

## Test plan
- [x] Vérifié que les 16 communes signalées dans l'issue fonctionnent après le fix
- [x] Tests existants toujours passants (les 12 échecs dans `flux.comparison.test.js` sont pré-existants)