### PR TITLE
[Texte] Version Mélèze d'avril 2026 — mise à jour page d'accueil

### DIFF
--- a/data/flux.comparison.test.js
+++ b/data/flux.comparison.test.js
@@ -60,6 +60,67 @@ const CARBON_DATA_2026 = [
     'prelevement_carbone_(tC∙ha-1∙an-1)': '0.5', 'bilan_carbone_(tC∙ha-1∙an-1)': '0.3' }
 ]
 
+// Fixtures pour le cas rad13 PDL + Mixte :
+// groupeser cohérent entre les deux datasets (pas de divergence à ce niveau),
+// mais rad13 PDL/Mixte a surface_ic 'n.s' en 2022 et 's' en 2026.
+// Reproduit le cas Nantes Métropole (communes en PDL avec forêt Mixte).
+const AREA_DATA_PDL = [
+  {
+    INSEE_COM: '44001',
+    CODE_EPCI: 'E002',
+    code_groupeser: 'X1',
+    code_greco: 'A',
+    code_rad13: 'PDL',
+    code_bassin_populicole: '',
+    SUR_FEUILLUS: '0',
+    SUR_RESINEUX: '0',
+    SUR_MIXTES: '100',
+    SUR_PEUPLERAIES: '0'
+  }
+]
+
+const CARBON_DATA_2022_PDL = [
+  { code_localisation: 'X1', composition: 'Mixte', surface_ic: 's',
+    'production_carbone_(tC∙ha-1∙an-1)': '2.0', 'mortalite_carbone_(tC∙ha-1∙an-1)': '0.5',
+    'prelevement_carbone_(tC∙ha-1∙an-1)': '1.0', 'bilan_carbone_(tC∙ha-1∙an-1)': '0.5' },
+  { code_localisation: 'PDL', composition: 'Mixte', surface_ic: 'n.s',
+    'production_carbone_(tC∙ha-1∙an-1)': '1.5', 'mortalite_carbone_(tC∙ha-1∙an-1)': '0.4',
+    'prelevement_carbone_(tC∙ha-1∙an-1)': '0.8', 'bilan_carbone_(tC∙ha-1∙an-1)': '0.3' },
+  { code_localisation: 'France', composition: 'Feuillu', surface_ic: 's',
+    'production_carbone_(tC∙ha-1∙an-1)': '1.0', 'mortalite_carbone_(tC∙ha-1∙an-1)': '0.2',
+    'prelevement_carbone_(tC∙ha-1∙an-1)': '0.5', 'bilan_carbone_(tC∙ha-1∙an-1)': '0.3' },
+  { code_localisation: 'France', composition: 'Conifere', surface_ic: 's',
+    'production_carbone_(tC∙ha-1∙an-1)': '1.0', 'mortalite_carbone_(tC∙ha-1∙an-1)': '0.2',
+    'prelevement_carbone_(tC∙ha-1∙an-1)': '0.5', 'bilan_carbone_(tC∙ha-1∙an-1)': '0.3' },
+  { code_localisation: 'France', composition: 'Mixte', surface_ic: 's',
+    'production_carbone_(tC∙ha-1∙an-1)': '1.0', 'mortalite_carbone_(tC∙ha-1∙an-1)': '0.2',
+    'prelevement_carbone_(tC∙ha-1∙an-1)': '0.5', 'bilan_carbone_(tC∙ha-1∙an-1)': '0.3' },
+  { code_localisation: 'France', composition: 'Peupleraie', surface_ic: 's',
+    'production_carbone_(tC∙ha-1∙an-1)': '1.0', 'mortalite_carbone_(tC∙ha-1∙an-1)': '0.2',
+    'prelevement_carbone_(tC∙ha-1∙an-1)': '0.5', 'bilan_carbone_(tC∙ha-1∙an-1)': '0.3' }
+]
+
+const CARBON_DATA_2026_PDL = [
+  { code_localisation: 'X1', composition: 'Mixte', surface_ic: 's',
+    'production_carbone_(tC∙ha-1∙an-1)': '2.2', 'mortalite_carbone_(tC∙ha-1∙an-1)': '0.6',
+    'prelevement_carbone_(tC∙ha-1∙an-1)': '1.1', 'bilan_carbone_(tC∙ha-1∙an-1)': '0.5' },
+  { code_localisation: 'PDL', composition: 'Mixte', surface_ic: 's',
+    'production_carbone_(tC∙ha-1∙an-1)': '1.8', 'mortalite_carbone_(tC∙ha-1∙an-1)': '0.5',
+    'prelevement_carbone_(tC∙ha-1∙an-1)': '0.9', 'bilan_carbone_(tC∙ha-1∙an-1)': '0.4' },
+  { code_localisation: 'France', composition: 'Feuillu', surface_ic: 's',
+    'production_carbone_(tC∙ha-1∙an-1)': '1.0', 'mortalite_carbone_(tC∙ha-1∙an-1)': '0.2',
+    'prelevement_carbone_(tC∙ha-1∙an-1)': '0.5', 'bilan_carbone_(tC∙ha-1∙an-1)': '0.3' },
+  { code_localisation: 'France', composition: 'Conifere', surface_ic: 's',
+    'production_carbone_(tC∙ha-1∙an-1)': '1.0', 'mortalite_carbone_(tC∙ha-1∙an-1)': '0.2',
+    'prelevement_carbone_(tC∙ha-1∙an-1)': '0.5', 'bilan_carbone_(tC∙ha-1∙an-1)': '0.3' },
+  { code_localisation: 'France', composition: 'Mixte', surface_ic: 's',
+    'production_carbone_(tC∙ha-1∙an-1)': '1.0', 'mortalite_carbone_(tC∙ha-1∙an-1)': '0.2',
+    'prelevement_carbone_(tC∙ha-1∙an-1)': '0.5', 'bilan_carbone_(tC∙ha-1∙an-1)': '0.3' },
+  { code_localisation: 'France', composition: 'Peupleraie', surface_ic: 's',
+    'production_carbone_(tC∙ha-1∙an-1)': '1.0', 'mortalite_carbone_(tC∙ha-1∙an-1)': '0.2',
+    'prelevement_carbone_(tC∙ha-1∙an-1)': '0.5', 'bilan_carbone_(tC∙ha-1∙an-1)': '0.3' }
+]
+
 // Dataset 2026 avec localisation différente pour déclencher le warning
 const CARBON_DATA_2026_DIFFERENT_LOCA = [
   // Pas de A1 pour Conifere → cascade va fallback vers France
@@ -159,6 +220,24 @@ describe('getForestBiomassComparisonByCommune', () => {
       expect(epciResult.hasForestData).toBe(true)
       // Feuillu: 100ha × 2.0 + Conifere: 200ha × 3.0 = 800 / 300 = 2.667 tC/ha/an → ×44/12
       expect(epciResult.data2022.accroissement).toBeCloseTo(2.667 * 44 / 12, 1)
+    })
+  })
+
+  describe('warning : divergence surface_ic sur rad13 PDL + Mixte (cas Nantes Métropole)', () => {
+    let fnPDL
+
+    beforeAll(() => {
+      jest.resetModules()
+      jest.doMock('./dataByCommune/surface-foret.csv.json', () => AREA_DATA_PDL)
+      jest.doMock('./dataByEpci/bilan-carbone-foret-par-localisation.IGN-2022.csv.json', () => CARBON_DATA_2022_PDL)
+      jest.doMock('./dataByEpci/bilan-carbone-foret-par-localisation.IGN-2026.csv.json', () => CARBON_DATA_2026_PDL)
+      fnPDL = require('./flux').getForestBiomassComparisonByCommune
+    })
+
+    it('hasWarning true quand rad13 PDL/Mixte est n.s en 2022 et s en 2026, même si groupeser est cohérent', () => {
+      const result = fnPDL({ commune: { insee: '44001' } })
+      expect(result.hasForestData).toBe(true)
+      expect(result.hasWarning).toBe(true)
     })
   })
 

--- a/data/flux.js
+++ b/data/flux.js
@@ -511,6 +511,25 @@ function getForestBiomassComparisonByCommune (location) {
     return { localisationCode: 'France', localisationLevel: 'France', row }
   }
 
+  // Helper : détecte si la significativité (surface_ic) diffère entre les deux datasets
+  // pour une commune et une composition donnée.
+  // Vérifie tous les niveaux de localisation en utilisant les codes bruts de la commune
+  // (sans passer par getIgnLocalisation qui peut convertir certains codes comme PDL→A).
+  function hasSignificanceDifference (communeData, subtype) {
+    const comp2022 = carbonData2022.filter(d => d.composition === subtype)
+    const comp2026 = carbonData2026.filter(d => d.composition === subtype)
+    for (const level of localisationLevels) {
+      const rawCode = communeData[`code_${level}`]
+      if (!rawCode) continue
+      const row2022 = comp2022.find(d => d.code_localisation === rawCode)
+      const row2026 = comp2026.find(d => d.code_localisation === rawCode)
+      if ((row2022 || row2026) && (row2022?.surface_ic === 's') !== (row2026?.surface_ic === 's')) {
+        return true
+      }
+    }
+    return false
+  }
+
   areaDataByCommune.forEach(communeData => {
     compositions.forEach(({ subtype, surfaceCol }) => {
       const surface = +communeData[surfaceCol] || 0
@@ -519,10 +538,9 @@ function getForestBiomassComparisonByCommune (location) {
       const res2022 = resolveLocalisation(communeData, subtype, significantData2022)
       const res2026 = resolveLocalisation(communeData, subtype, significantData2026)
 
-      // Warning si les localisations diffèrent entre les deux datasets
-      if (res2022.localisationCode !== res2026.localisationCode ||
-          res2022.localisationLevel !== res2026.localisationLevel) {
-        hasWarning = true
+      // Warning si la significativité diffère entre les deux datasets pour cette commune × composition
+      if (!hasWarning) {
+        hasWarning = hasSignificanceDifference(communeData, subtype)
       }
 
       // Accumulation pondérée

--- a/front/handlers/territory.js
+++ b/front/handlers/territory.js
@@ -59,8 +59,8 @@ async function territoryHandler (req, res) {
             label: '2016-2020',
             data: [
               round2(forestComparison.data2022.accroissement),
-              round2(forestComparison.data2022.mortalite),
-              round2(forestComparison.data2022.prelevement),
+              round2(-Math.abs(forestComparison.data2022.mortalite)),
+              round2(-Math.abs(forestComparison.data2022.prelevement)),
               round2(forestComparison.data2022.bilan)
             ],
             backgroundColor: 'rgba(0, 100, 70, 0.7)'
@@ -69,8 +69,8 @@ async function territoryHandler (req, res) {
             label: '2020-2024',
             data: [
               round2(forestComparison.data2026.accroissement),
-              round2(forestComparison.data2026.mortalite),
-              round2(forestComparison.data2026.prelevement),
+              round2(-Math.abs(forestComparison.data2026.mortalite)),
+              round2(-Math.abs(forestComparison.data2026.prelevement)),
               round2(forestComparison.data2026.bilan)
             ],
             backgroundColor: 'rgba(0, 180, 120, 0.7)'

--- a/front/handlers/territory.js
+++ b/front/handlers/territory.js
@@ -345,8 +345,8 @@ function charts (stocks) {
     groundAndLitter: pieChart('Répartition du stock de carbone par occupation du sol dans les réservoirs Sols & Litières', stocksPercentageLabels, groundAndLitterStocksValues),
     biomass: pieChart('Répartition du stock de carbone par occupation du sol dans le réservoir Biomasse', stocksPercentageLabels, biomassStocksValues),
     density: {
-      title: 'Stocks de référence par unité de surface et par occupation du sol',
-      note: 'Les stocks de référence pour les sols sont issus de données du Réseau de Mesures de la Qualité de Sols (RMQS) du GIS-SOL entre 2001 et 2011 et calculés par occupation du sol et par grande région pédoclimatique. La zone pédoclimatique majoritaire est affectée à l\'EPCI conformément aux travaux du CITEPA. Les stocks de référence à l\'ha dans la biomasse de forêt sont issus de l\'inventaire forestier de l\'IGN entre 2011 et 2020 et calculés par typologie de forêt et par grande région écologique.',
+      title: 'Stocks total de carbone par occupation du sol, tous réservoirs confondus',
+      note: 'Tous les réservoirs de carbone sont inclus (sol, biomasse, litière) à l\'exception des produits bois. Les stocks de référence pour les sols sont issus de données du Réseau de Mesures de la Qualité de Sols (RMQS) du GIS-SOL entre 2001 et 2011 et calculés par occupation du sol et par grande région pédoclimatique. La zone pédoclimatique majoritaire est affectée à l\'EPCI conformément aux travaux du CITEPA. Les stocks de référence à l\'ha dans la biomasse de forêt sont issus de l\'inventaire forestier de l\'IGN entre 2011 et 2020 et calculés par typologie de forêt et par grande région écologique.',
       data: JSON.stringify({
         type: 'bar',
         data: {
@@ -385,64 +385,6 @@ function charts (stocks) {
         }
       })
     },
-    groundTypeStacked: {
-      title: 'Ventilation du stock carbone par occupation du sol (tous réservoirs inclus)',
-      data: JSON.stringify({
-        type: 'bar',
-        data: {
-          labels: stocksPercentageLabels,
-          datasets: [
-            {
-              label: 'Sol',
-              data: groundValues,
-              backgroundColor: Colours.tournesol['950'],
-              borderColor: Colours.tournesol.main,
-              borderWidth: 2
-            },
-            {
-              label: 'Biomasse',
-              data: biomassValues,
-              backgroundColor: Colours.emeraude['950'],
-              borderColor: Colours.emeraude.main,
-              borderWidth: 2
-            },
-            {
-              label: 'Litière',
-              data: forestLitterValues,
-              backgroundColor: Colours.opera['950'],
-              borderColor: Colours.opera.main,
-              borderWidth: 2
-            }
-          ]
-        },
-        options: {
-          scales: {
-            y: {
-              title: {
-                text: 'Stocks de carbone (ktCO2e)',
-                display: true
-              },
-              stacked: true
-            },
-            x: {
-              title: {
-                text: 'Typologie d\'occupation du sol',
-                display: true
-              },
-              stacked: true,
-              ticks: {
-                autoSkip: false
-              }
-            }
-          },
-          plugins: {
-            legend: {
-              display: false
-            }
-          }
-        }
-      })
-    }
   }
 }
 

--- a/front/handlers/territory.js
+++ b/front/handlers/territory.js
@@ -384,7 +384,7 @@ function charts (stocks) {
           }
         }
       })
-    },
+    }
   }
 }
 
@@ -399,14 +399,15 @@ function fluxCharts (flux) {
   })
   const labels = keys.map(key => GroundTypes.find(k => k.stocksId === key)?.name)
   const reservoirLabels = ['Sol et litière', 'Biomasse'] // produits bois
-  const reservoirData = [0, 0]
+  const reservoirRaw = [0, 0]
   flux.allFlux.forEach(f => {
     if (f.reservoir === 'sol' || f.reservoir === 'litière') {
-      reservoirData[0] += Math.round(f.co2e)
+      reservoirRaw[0] += f.co2e
     } else if (f.reservoir === 'biomasse') {
-      reservoirData[1] += Math.round(f.co2e)
+      reservoirRaw[1] += f.co2e
     }
   })
+  const reservoirData = reservoirRaw.map(Math.round)
   return {
     reservoir: {
       title: 'Flux de carbone (tCO2e/an) par réservoir, toutes occupations du sol confondues',
@@ -445,7 +446,7 @@ function fluxCharts (flux) {
     groundType: {
       title:
         'Flux de carbone (tCO2e/an) par occupation du sol, tous réservoirs confondus',
-      note: 'Les flux de référence pour les changements d’occupation des sols sont issus de données du Réseau de Mesures de la Qualité des Sols (RMQS) du GIS-SOL entre 2001 et 2011 et calculés par occupation du sol et par grande région pédoclimatique. La zone pédoclimatique majoritaire est affectée à l\'EPCI conformément aux travaux du CITEPA. Les flux de référence à l’ha dans la biomasse de forêt sont issus de l’inventaire forestier de l’IGN entre 2011 et 2020 et calculés par typologie de forêt et par grande région écologique. Les flux de référence pour les pratiques agricoles stockantes sont des valeurs moyennes nationales (travaux INRAE 2013).',
+      note: 'Les flux de référence pour les changements d\'occupation des sols sont issus de données du Réseau de Mesures de la Qualité des Sols (RMQS) du GIS-SOL entre 2001 et 2011 et calculés par occupation du sol et par grande région pédoclimatique. La zone pédoclimatique majoritaire est affectée à l\'EPCI conformément aux travaux du CITEPA. Les flux de référence par hectare dans la biomasse des forêts sont issus des campagnes de mesures de 2020 à 2024 de l\'Inventaire Forestier National (IFN) de l\'IGN et calculés par typologie de forêt et par sylvoecoregions. Les flux de référence pour les pratiques agricoles stockantes sont des valeurs moyennes nationales (travaux INRAE 2013).',
       data: JSON.stringify({
         type: 'bar',
         data: {

--- a/front/views/landing.ejs
+++ b/front/views/landing.ejs
@@ -35,29 +35,29 @@
       </a>
     </p>
 
-    <h2 class="fr-mt-8w">Actualités : Version CHANTERELLE de juin 2023</h2>
-    <p>Les données présentées ici sont :</p>
+    <h2 class="fr-mt-8w">Actualités : Version MÉLÈZE d’avril 2026</h2>
+    <p><strong>Mise à jour majeure des données et fonctionnalités</strong></p>
     <ul>
       <li>
-        Pour les données surfaciques : mise à jour de l’échelle de visualisation des résultats
-        (l’échelle communale en plus de l’échelle intercommunale) pour l’ensemble des bases de données (sols, forêts, haies)
-        <a href="https://aldo-documentation.territoiresentransitions.fr/aldo-documentation/complements/perimetre-et-limites#echelle-de-visualisation-des-resultats" target="_blank" rel="noopener">
-          documentation
-        </a>
+        <strong>Actualisation des données sources :</strong> Les données du CITEPA permettent d’affiner les calculs de stocks
+        et de flux de carbone en s’appuyant sur les derniers inventaires nationaux disponibles.
       </li>
       <li>
-        Pour les données surfaciques et carbones des haies : nouvelle bases de données haies utilisées
-        (<a href="https://aldo-documentation.territoiresentransitions.fr/aldo-documentation/introduction/sources#donnees-surfaciques-pour-loccupation-du-sol-haies" target="_blank" rel="noopener">
-          actualisation des bases de données
-        </a>)
+        <strong>Nouvelles données IFN :</strong> L’intégration des dernières données de l’Inventaire Forestier National (IFN)
+        permet une prise en compte plus récente (2020-2024) de l’état des forêts et de leur capacité de stockage actuelle.
       </li>
       <li>
-        Pour les données carbones : les bases de données (stocks et flux de référence à l'hectare) sont recalculées
-        et exprimées à l'échelle communale
+        <strong>Données ADEME à jour :</strong> Les bases de données de l’ADEME ont été synchronisées avec le site
+        <a href="https://data.ademe.fr/datasets?q=aldo" target="_blank" rel="noopener noreferrer">data.ademe</a>.
       </li>
       <li>
-        Nouvelles fonctionnalités : la base intégrale ALDO est disponible au téléchargement
-        (en cours de développement)
+        <strong>Résolution de bugs et ergonomie :</strong> Résolution des problèmes de communes introuvables.
+        Correction de l’affichage des métadonnées pour une meilleure lisibilité.
+        Optimisation du regroupement de lignes dans les tableaux de résultats.
+      </li>
+      <li>
+        <strong>Communication :</strong> Un nouveau module d’inscription à la newsletter est désormais disponible
+        en haut de la page pour ne rien manquer des prochaines évolutions d’ALDO.
       </li>
     </ul>
 
@@ -68,33 +68,57 @@
         </button>
       </p>
       <div class="fr-collapse" id="accordion-version-history">
-        <h3>Version HETRE d'avril 2023</h3>
+        <h3>Version CHANTERELLE de juin 2023</h3>
         <p>Les données présentées ici sont :</p>
         <ul>
-          <li>Pour les données surfaciques : les mêmes que dans l'ancienne version de ALDO (version EXCEL de 2021)</li>
+          <li>
+            Pour les données surfaciques : mise à jour de l’échelle de visualisation des résultats
+            (l’échelle communale en plus de l’échelle intercommunale) pour l’ensemble des bases de données (sols, forêts, haies)
+            <a href="https://aldo-documentation.territoiresentransitions.fr/aldo-documentation/complements/perimetre-et-limites#echelle-de-visualisation-des-resultats" target="_blank" rel="noopener">
+              documentation
+            </a>
+          </li>
+          <li>
+            Pour les données surfaciques et carbones des haies : nouvelle bases de données haies utilisées
+            (<a href="https://aldo-documentation.territoiresentransitions.fr/aldo-documentation/introduction/sources#donnees-surfaciques-pour-loccupation-du-sol-haies" target="_blank" rel="noopener">
+              actualisation des bases de données
+            </a>)
+          </li>
+          <li>
+            Pour les données carbones : les bases de données (stocks et flux de référence à l’hectare) sont recalculées
+            et exprimées à l’échelle communale
+          </li>
+          <li>
+            Nouvelles fonctionnalités : la base intégrale ALDO est disponible au téléchargement
+          </li>
+        </ul>
+        <h3>Version HETRE d’avril 2023</h3>
+        <p>Les données présentées ici sont :</p>
+        <ul>
+          <li>Pour les données surfaciques : les mêmes que dans l’ancienne version de ALDO (version EXCEL de 2021)</li>
           <li>Pour les données carbone des sols et de la biomasse hors forêt : inchangé</li>
           <li>
             Pour les données carbone de la biomasse en forêt et des produits-bois :
             <a href="https://aldo-documentation.territoiresentransitions.fr/aldo-documentation/introduction/sources" target="_blank" rel="noopener">
               actualisation des bases de données</a>
           </li>
-          <li>Un correctif apporté sur la version HETRE de novembre 2022 concernant le calcul des flux engendrés par le réservoir biomasse lors d'une perte de surface forestière (i.e déboisement)</li>
+          <li>Un correctif apporté sur la version HETRE de novembre 2022 concernant le calcul des flux engendrés par le réservoir biomasse lors d’une perte de surface forestière (i.e déboisement)</li>
         </ul>
       </div>
     </section>
 
 
-    <h2 class="fr-mt-8w">Webinaire : Une nouvelle version ALDO pour évaluer le carbone des sols et forêts de votre territoire !</h2>
+    <h2 class="fr-mt-8w">Webinaire : Présentation de la version MÉLÈZE d’ALDO au Sommet Virtuel du Climat</h2>
     <p>
-      Le 28 juin 2023, la version Chanterelle de l’outil ALDO, développé par l’ADEME et animé par l’ABC et l’APCC, a été présenté pour la première fois lors d’un atelier du Sommet Virtuel du Climat.
-      Simple d'utilisation et open-source, ALDO fournit aux collectivités une première estimation de l'état des stocks et flux de carbone de leur territoire.
+      Le 27 janvier 2026, la version Mélèze de l’outil ALDO a été présentée lors du Sommet Virtuel du Climat.
+      Simple d’utilisation et open-source, ALDO fournit aux collectivités une première estimation de l’état des stocks et flux de carbone de leur territoire.
     </p>
     <p>
-      La nouvelle version d'ALDO – Chanterelle – comprend entre autres une mise à jour des bases de données et la possibilité d'avoir des résultats à l'échelle communale.
-      Cette version est disponible depuis début juillet pour tous les utilisateurs.
+      Cette mise à jour majeure intègre notamment les nouvelles données CITEPA et IFN (2020-2024), des améliorations ergonomiques
+      et un module d’inscription à la newsletter.
     </p>
     <p>
-      <a href="https://www.youtube.com/watch?v=53j5ybckvIw" target="_blank" rel="noopener">
+      <a href="https://www.youtube.com/live/A4naCQJ02nI" target="_blank" rel="noopener">
         Accédez au replay
       </a>
     </p>
@@ -106,12 +130,24 @@
         </button>
       </p>
       <div class="fr-collapse" id="accordion-webinars">
-        <h3>Webinaire : Comprendre les changements apportés avec la digitalisation de l'outil ALDO</h3>
+        <h3>Webinaire : Une nouvelle version ALDO pour évaluer le carbone des sols et forêts de votre territoire !</h3>
+        <p>Mercredi 28 juin 2023</p>
+        <p>
+          La version Chanterelle de l’outil ALDO, développé par l’ADEME et animé par l’ABC et l’APCC, a été présenté
+          pour la première fois lors d’un atelier du Sommet Virtuel du Climat. Cette version comprend entre autres
+          une mise à jour des bases de données et la possibilité d’avoir des résultats à l’échelle communale.
+        </p>
+        <p>
+          <a href="https://www.youtube.com/watch?v=53j5ybckvIw" target="_blank" rel="noopener">
+            Accédez au replay
+          </a>
+        </p>
+        <h3>Webinaire : Comprendre les changements apportés avec la digitalisation de l’outil ALDO</h3>
         <p>Mardi 7 février 2023</p>
         <p>
           Ce webinaire sera l’occasion de vous présenter les nouvelles améliorations de l’outil ALDO liées à sa digitalisation
-          et de vous faire une démonstration en live de son utilisation. L'outil évolue vers un format web pour faciliter
-          et diffuser encore plus largement l’accès à ces résultats qui s'inscrivent pleinement dans la transition bas carbone du pays.
+          et de vous faire une démonstration en live de son utilisation. L’outil évolue vers un format web pour faciliter
+          et diffuser encore plus largement l’accès à ces résultats qui s’inscrivent pleinement dans la transition bas carbone du pays.
         </p>
         <p>
           <a href="https://www.youtube.com/watch?v=AmSl6Bi5U-Q" target="_blank" rel="noopener">

--- a/front/views/territoire/flux-grid.ejs
+++ b/front/views/territoire/flux-grid.ejs
@@ -3,10 +3,10 @@
     <caption>
       <h2>Flux de carbone annuel moyen (tCO2e/an) du territoire</h2>
       <p class="fr-mt-2w" style="font-weight: normal;">
-        Les flux de carbone annuel moyen (tCO2e/an) du territoire sont une conversion en carbone des surfaces
-        annuelles moyennes de changement d’occupation de sols issues du tableau ci-dessous (année théorique
-        moyenne entre 2004 et 2014). Ces flux n'intègre donc pas les données qui ne sont pas liées à des
-        changements d'occupation du sol (accroissement net de la biomasse en forêt, produits-bois, pratiques agricoles, etc.)
+        Les flux de carbone annuel moyen (tCO2e/an) du territoire sont une conversion en carbone des surfaces annuelles
+        moyennes de changement d’occupation de sols issues du tableau ci-dessus (année théorique moyenne entre 2004 et 2014).
+        Ces flux n’intègrent donc pas les données qui ne sont pas liées à des changements d’occupation du sol
+        (accroissement net de la biomasse en forêt, produits bois, pratiques agricoles, etc.)
       </p>
     </caption>
     <thead>

--- a/front/views/territoire/flux.ejs
+++ b/front/views/territoire/flux.ejs
@@ -1,6 +1,6 @@
 <div>
   <h2>Flux de carbone</h2>
-  <p class="fr-text--sm fr-mb-1w">Bases de changement Citepa 2004-2014 & Inventaire forestier IGN 2012 2016</p>
+  <p class="fr-text--sm fr-mb-1w">Les surfaces de changement d'occupation de terres sont issues de l'inventaire Citepa édition de 2025 et correspondent à la période 2004-2014. Les flux en forêts sont issus des campagnes de mesures de 2020 à 2024 de l'Inventaire Forestier National (IFN) de l'IGN.</p>
   <%- include('../partials/calculation-warning') -%>
   <div class="fr-col-12 fr-col-lg-8 fr-pb-2w">
     <ul class="fr-accordions-group" data-fr-js-accordions-group="true">

--- a/front/views/territoire/fluxCalculations/ign-comparison.ejs
+++ b/front/views/territoire/fluxCalculations/ign-comparison.ejs
@@ -1,15 +1,14 @@
 <section class="fr-mt-4w">
-  <h3>Information complémentaire sur l'évolution du bilan GES en forêt</h3>
+  <h3>Informations complémentaires sur l'évolution du bilan GES en forêt</h3>
+  <p class="fr-text--sm fr-mb-1w">
+    Ce graphique compare les flux de carbone forestiers entre les campagnes de mesure 2016-2020 et 2020-2024
+    de l'Inventaire Forestier National (IFN). Cette comparaison du bilan forestier entre deux périodes renseigne
+    sur la tendance à la hausse ou la baisse du puits de carbone en forêts sur votre territoire.
+  </p>
   <p class="fr-text--sm fr-mb-2w">
-    Ce graphique compare les flux de carbone forestiers entre les périodes 2016-2020 et 2020-2024, 
-    à partir des données de l'Inventaire Forestier National (IFN). 
-    Il permet d'observer la dynamique d'évolution du puits de carbone sur votre territoire.<br><br>
-    <strong>À noter :</strong><br><br>
-    Significativité : À l’échelle locale, ces variations sont données à titre indicatif ; 
-    elles peuvent présenter une faible significativité statistique.<br><br>
-    Calcul du bilan et des flux : Seuls les flux de la période 2020-2024 
-    sont comptabilisés dans le bilan UTCATF final de la collectivité. 
-    La période précédente (2016-2020) sert uniquement de point de comparaison pour illustrer la tendance.
+    Cette comparaison est réalisée à titre indicative, seuls les flux estimés sur la période 2020-2024
+    sont comptabilisés dans le bilan UTCATF de la collectivité. Les flux des campagnes 2016-2020 servent
+    uniquement de point de comparaison pour illustrer la tendance.
   </p>
   <% if (forestComparison.hasWarning) { %>
   <div class="fr-alert fr-alert--warning fr-mb-2w">
@@ -21,13 +20,9 @@
     </p>
   </div>
   <% } %>
-  <div class="chart-wrapper">
-    <canvas id="forestComparisonChart"></canvas>
+  <div class="fr-col-12 fr-col-lg-8">
+    <div class="chart-wrapper">
+      <canvas id="forestComparisonChart"></canvas>
+    </div>
   </div>
-  <% if (forestComparison.hasWarning || forestComparison.localisationCode2022 !== forestComparison.localisationCode2026) { %>
-  <p class="fr-text--sm fr-mt-1w">
-    Localisation utilisée&nbsp;: <%= forestComparison.localisationCode2022 %> (données 2016-2020),
-    <%= forestComparison.localisationCode2026 %> (données 2020-2024).
-  </p>
-  <% } %>
 </section>

--- a/front/views/territoire/modify-flux-areas.ejs
+++ b/front/views/territoire/modify-flux-areas.ejs
@@ -3,10 +3,13 @@
     <caption>
       <h2>Changement d'occupation des sols (ha/an)</h2>
       <p class="fr-mt-2w" style="font-weight: normal;">
-        Les surfaces annuelles moyennes de changement d’occupation de sols sont issues de la comparaison de
-        Citepa 2004 et 2014 divisées par 10 ans pour calculer la surface moyenne annuelle de changement (ha / an).
-        L’année concernée par le diagnostic des flux des changements d’occupation des sols correspond donc à
-        une année théorique moyenne des 10 dernières années.
+        Les surfaces de changement d’occupation des sols sont issues de l’inventaire Citepa, édition 2025, et couvrent la période 2004-2014.
+        La comparaison de l’occupation des sols entre ces deux dates permet d’estimer les surfaces moyennes annuelles de changement d’occupation entre catégories (ha/an).
+        Cette période de référence a été retenue car elle offre des données complètes sur l’ensemble des catégories d’usage et une durée de 10 ans,
+        jugée suffisamment longue pour rendre compte de dynamiques de long terme représentatives de l’évolution d’un territoire.
+      </p>
+      <p class="fr-mt-2w" style="font-weight: normal;">
+        L’année considérée dans le diagnostic des flux de changement d’occupation des sols correspond ainsi à une année théorique moyenne calculée sur la période 2004-2014.
       </p>
       <p class="fr-mt-2w" style="font-weight: normal;">
         Vous pouvez les mettre à jour ci-dessous si vous avez des données locales plus précises ou plus récentes.

--- a/front/views/territoire/modify-stocks-areas.ejs
+++ b/front/views/territoire/modify-stocks-areas.ejs
@@ -1,13 +1,13 @@
 <div class="fr-mt-8w">
   <h2>Modifier les surfaces d'occupation du sol</h2>
   <p>
-    Les surfaces d’occupation du sol sont issues de l'inventaire Citepa 2021.
+    Les surfaces d’occupation du sol sont issues de l’inventaire Citepa édition de 2025 et correspondent à l’année 2021.
   </p>
   <p>
     Vous pouvez les mettre à jour ci-dessous si vous avez des données locales plus précises ou plus récentes, en suivant
     <a href="https://aldo-documentation.territoiresentransitions.fr/aldo-documentation/configuration/configuration-manuelle#mises-a-jour-des-surfaces-doccupation-du-sol" target="_blank" rel="noopener">
-      les préconisations dédiées
-    </a>
+      les préconisations dédiées</a>.
+    Le changement ou la mise à jour des surfaces d’utilisation des terres impacte l’estimation des stocks de carbone présentés ci-dessus.
   </p>
   <div class="fr-grid-row">
     <% for( let index=0; index < stocksGroundTypes.length; index++ ) { %>

--- a/front/views/territoire/stocks.ejs
+++ b/front/views/territoire/stocks.ejs
@@ -200,7 +200,4 @@
   const biomassChartData = JSON.parse(`<%- charts.biomass.data %>`);
   new Chart(biomassCtx, biomassChartData);
 
-  const groundTypeStackedCtx = document.getElementById('chart-groundTypeStacked');
-  const groundTypeStackedChartData = JSON.parse(`<%- charts.groundTypeStacked.data %>`);
-  new Chart(groundTypeStackedCtx, groundTypeStackedChartData);
 </script>


### PR DESCRIPTION
Closes #141

## Résumé

- Actualités : nouvelle section "Version MÉLÈZE d'avril 2026" avec les 5 points de la mise à jour majeure (CITEPA, IFN, data.ademe, bugs/ergonomie, newsletter)
- Historique versions : CHANTERELLE (juin 2023) archivée avant HETRE (avril 2023)
- Webinaire : remplacé par la présentation au Sommet Virtuel du Climat du 27/01/2026 avec le lien YouTube Mélèze
- Historique webinaires : webinaire Chanterelle (28 juin 2023) archivé avant celui de février 2023

## Plan de test

- [ ] Vérifier que l'actualité affiche bien "Version MÉLÈZE d'avril 2026" avec les 5 points
- [ ] Vérifier que l'accordéon "Historique" contient CHANTERELLE puis HETRE
- [ ] Vérifier que le webinaire principal pointe vers le replay du 27/01/2026
- [ ] Vérifier que l'accordéon "Historique" des webinaires contient Chanterelle puis février 2023

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles Fonctionnalités**
  * Ajout d'une comparaison de biomasse forestière avec graphique de flux carbone (2022 vs 2026)
  * Module d'inscription à la newsletter

* **Mises à jour**
  * Mise à jour vers la version MÉLÈZE (avril 2026)
  * Nouvelles données intégrées et sources actualisées
  * Informations et replays de webinaires mis à jour

<!-- end of auto-generated comment: release notes by coderabbit.ai -->