### PR TITLE
feat: message d'annonce décalage version Mélèze

### DIFF
--- a/front/views/landing.ejs
+++ b/front/views/landing.ejs
@@ -4,6 +4,26 @@
 
     <%- include('partials/newsletter-subscribe') -%>
 
+    <div class="fr-callout fr-my-4w">
+      <h3 class="fr-callout__title">📢 Actualité : Version Mélèze 2026</h3>
+      <p class="fr-callout__text fr-mb-2w">
+        Nous tenions à vous informer d'un léger décalage dans le déploiement de la nouvelle version d'ALDO, initialement prévue pour la fin mars.
+      </p>
+      <p class="fr-callout__text fr-mb-2w">
+        <strong>Pourquoi ce délai ?</strong><br>
+        Lors de nos phases finales de contrôle, nous avons identifié des besoins de recalage technique, notamment sur les données de surface de défrichement et l'harmonisation des données du produit OCS GE. Ce temps supplémentaire nous permet de corriger les anomalies détectées. Le travail de correction et d'intégration est en cours. Nous prévoyons une mise en ligne d'ici mi-mai.
+      </p>
+      <p class="fr-callout__text fr-mb-2w">
+        Nous vous tiendrons informés lors de la publication de cette nouvelle version de l'outil ALDO.
+      </p>
+      <p class="fr-callout__text fr-mb-2w">
+        Merci de votre patience et de votre confiance !<br>
+      </p>
+      <p class="fr-callout__text fr-mb-2w">
+        <strong>L'équipe Projet ALDO</strong>
+      </p>
+    </div>
+
     <div class="fr-py-6w">
       <h1>Calculer le stock et les flux de carbone sur votre territoire</h1>
 


### PR DESCRIPTION
## Summary
- Ajoute un encadré d'actualité (composant DSFR `fr-callout`) sur la page d'accueil informant du décalage de la version Mélèze 2026
- Positionné entre la newsletter et le bloc de recherche pour une bonne visibilité

Closes #178

## Test plan
- [ ] Vérifier l'affichage de l'encadré sur la page d'accueil
- [ ] Vérifier le rendu responsive (mobile/tablette/desktop)
- [ ] Vérifier que le texte correspond au contenu demandé dans l'issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Mises à jour**
  * Ajout d’un encart informatif en français sur la page d’accueil annonçant la « Version Mélèze 2026 ». Le message explique le report du déploiement initialement prévu fin mars à mi-mai, décrit brièvement les causes et les travaux de correction en cours, et se termine par un mot de l’équipe projet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->