### PR TITLE
Corrige les extractions DATA ADEME flux EPCI (#189)

### DIFF
--- a/scripts/generate-flux1-csv.js
+++ b/scripts/generate-flux1-csv.js
@@ -66,99 +66,6 @@ const fluxGroundTypes = GroundTypes.filter((gt) => gt.altFluxId || gt.fluxId)
 // (les 12 paires forêt-vers-forêt sont absentes car traitées via la biomasse)
 const forestSubtypeIds = ['forêt mixte', 'forêt feuillu', 'forêt conifere', 'forêt peupleraie']
 
-// Paires pour lesquelles une colonne tCO2e existe dans le fichier de référence.
-// Déterminé en analysant le fichier aldo-flux-total-et-surfaces-converties.csv
-// (tous les cas où le flux unitaire n'est pas nul pour au moins une commune).
-const PAIRS_WITH_CO2E = new Set([
-  'cultures_vers_prairies zones herbacées',
-  'cultures_vers_zones humides',
-  'cultures_vers_vergers',
-  'cultures_vers_vignes',
-  'cultures_vers_sols artificiels arbustifs',
-  'cultures_vers_sols artificiels imperméabilisés',
-  'cultures_vers_sols artificiels arborés et buissonants',
-  'cultures_vers_forêt mixte',
-  'cultures_vers_forêt conifere',
-  'prairies zones arborées_vers_cultures',
-  'prairies zones arborées_vers_prairies zones herbacées',
-  'prairies zones arborées_vers_vignes',
-  'prairies zones arborées_vers_sols artificiels arbustifs',
-  'prairies zones arborées_vers_sols artificiels imperméabilisés',
-  'prairies zones arborées_vers_forêt mixte',
-  'prairies zones herbacées_vers_cultures',
-  'prairies zones herbacées_vers_prairies zones arborées',
-  'prairies zones herbacées_vers_prairies zones arbustives',
-  'prairies zones herbacées_vers_zones humides',
-  'prairies zones herbacées_vers_vergers',
-  'prairies zones herbacées_vers_vignes',
-  'prairies zones herbacées_vers_sols artificiels arbustifs',
-  'prairies zones herbacées_vers_sols artificiels imperméabilisés',
-  'prairies zones herbacées_vers_forêt mixte',
-  'prairies zones herbacées_vers_forêt conifere',
-  'prairies zones arbustives_vers_cultures',
-  'prairies zones arbustives_vers_prairies zones herbacées',
-  'prairies zones arbustives_vers_zones humides',
-  'prairies zones arbustives_vers_vignes',
-  'prairies zones arbustives_vers_sols artificiels imperméabilisés',
-  'prairies zones arbustives_vers_forêt mixte',
-  'prairies zones arbustives_vers_forêt feuillu',
-  'prairies zones arbustives_vers_forêt conifere',
-  'zones humides_vers_cultures',
-  'zones humides_vers_prairies zones herbacées',
-  'zones humides_vers_prairies zones arbustives',
-  'zones humides_vers_sols artificiels arbustifs',
-  'zones humides_vers_sols artificiels imperméabilisés',
-  'zones humides_vers_forêt mixte',
-  'vergers_vers_cultures',
-  'vergers_vers_prairies zones herbacées',
-  'vergers_vers_zones humides',
-  'vergers_vers_sols artificiels arbustifs',
-  'vergers_vers_sols artificiels imperméabilisés',
-  'vignes_vers_cultures',
-  'vignes_vers_prairies zones arbustives',
-  'vignes_vers_zones humides',
-  'vignes_vers_vergers',
-  'vignes_vers_sols artificiels arbustifs',
-  'vignes_vers_sols artificiels imperméabilisés',
-  'vignes_vers_forêt conifere',
-  'sols artificiels arbustifs_vers_cultures',
-  'sols artificiels arbustifs_vers_prairies zones herbacées',
-  'sols artificiels arbustifs_vers_zones humides',
-  'sols artificiels arbustifs_vers_vignes',
-  'sols artificiels arbustifs_vers_forêt mixte',
-  'sols artificiels arbustifs_vers_forêt feuillu',
-  'sols artificiels imperméabilisés_vers_prairies zones herbacées',
-  'sols artificiels imperméabilisés_vers_prairies zones arbustives',
-  'sols artificiels imperméabilisés_vers_zones humides',
-  'sols artificiels imperméabilisés_vers_vignes',
-  'sols artificiels imperméabilisés_vers_sols artificiels arborés et buissonants',
-  'sols artificiels imperméabilisés_vers_forêt mixte',
-  'sols artificiels imperméabilisés_vers_forêt feuillu',
-  'sols artificiels arborés et buissonants_vers_sols artificiels arbustifs',
-  'sols artificiels arborés et buissonants_vers_sols artificiels imperméabilisés',
-  'forêt mixte_vers_cultures',
-  'forêt mixte_vers_prairies zones arborées',
-  'forêt mixte_vers_prairies zones herbacées',
-  'forêt mixte_vers_prairies zones arbustives',
-  'forêt mixte_vers_zones humides',
-  'forêt mixte_vers_vignes',
-  'forêt mixte_vers_sols artificiels arbustifs',
-  'forêt mixte_vers_sols artificiels imperméabilisés',
-  'forêt feuillu_vers_cultures',
-  'forêt feuillu_vers_prairies zones herbacées',
-  'forêt feuillu_vers_prairies zones arbustives',
-  'forêt feuillu_vers_zones humides',
-  'forêt feuillu_vers_vergers',
-  'forêt feuillu_vers_sols artificiels arbustifs',
-  'forêt feuillu_vers_sols artificiels imperméabilisés',
-  'forêt conifere_vers_cultures',
-  'forêt conifere_vers_prairies zones herbacées',
-  'forêt conifere_vers_prairies zones arbustives',
-  'forêt conifere_vers_zones humides',
-  'forêt conifere_vers_vignes',
-  'forêt conifere_vers_sols artificiels arbustifs',
-  'forêt conifere_vers_sols artificiels imperméabilisés'
-])
 
 // ---------------------------------------------------------------------------
 // Construction des en-têtes CSV
@@ -176,9 +83,7 @@ function buildHeaders () {
       if (forestSubtypeIds.includes(fromGt.stocksId) && forestSubtypeIds.includes(toGt.stocksId)) return
       const pairKey = `${fromGt.stocksId}_vers_${toGt.stocksId}`
       headers.push(`${pairKey}_surface_ha_an-1`)
-      if (PAIRS_WITH_CO2E.has(pairKey)) {
-        headers.push(`${pairKey}_tCO2e_an-1`)
-      }
+      headers.push(`${pairKey}_tCO2e_an-1`)
     })
   })
   return headers
@@ -255,14 +160,11 @@ function generate (outputPath) {
         if (fromGt.stocksId === toGt.stocksId) return
         if (forestSubtypeIds.includes(fromGt.stocksId) && forestSubtypeIds.includes(toGt.stocksId)) return
 
-        const pairKey = `${fromGt.stocksId}_vers_${toGt.stocksId}`
         const surface = areas[fromGt.stocksId]?.[toGt.stocksId]?.area
         row.push(surface !== undefined && surface !== null ? surface : 0)
 
-        if (PAIRS_WITH_CO2E.has(pairKey)) {
-          const co2e = fluxCo2eByGroundType[fromGt.stocksId]?.[toGt.stocksId]
-          row.push(co2e ?? '')
-        }
+        const co2e = fluxCo2eByGroundType[fromGt.stocksId]?.[toGt.stocksId]
+        row.push(co2e ?? '')
       })
     })
 

--- a/scripts/generate-flux1-epci-csv.js
+++ b/scripts/generate-flux1-epci-csv.js
@@ -8,25 +8,6 @@ const { getEpcis, getEPCIBaseMeta } = require('./generate-epci-utils')
 const fluxGroundTypes = GroundTypes.filter((gt) => gt.altFluxId || gt.fluxId)
 const forestSubtypeIds = ['forêt mixte', 'forêt feuillu', 'forêt conifere', 'forêt peupleraie']
 
-function parseQuotedHeaders (line) {
-  const matches = line.match(/"((?:[^"]|"")*)"/g) || []
-  return matches.map((m) => m.slice(1, -1).replace(/""/g, '"'))
-}
-
-function getPairsWithCo2eFromReference () {
-  const referencePath = path.join(__dirname, '../flux1.csv')
-  const firstLine = fs.readFileSync(referencePath, 'utf8').split('\n')[0]
-  const headers = parseQuotedHeaders(firstLine)
-  const pairs = new Set()
-  headers.forEach((header) => {
-    if (!header.endsWith('_tCO2e_an-1')) return
-    pairs.add(header.replace(/_tCO2e_an-1$/, ''))
-  })
-  return pairs
-}
-
-const PAIRS_WITH_CO2E = getPairsWithCo2eFromReference()
-
 function buildHeaders () {
   const headers = [
     'insee', 'nom', 'epci', 'departement', 'region', 'zpc',
@@ -39,7 +20,7 @@ function buildHeaders () {
       if (forestSubtypeIds.includes(fromGt.stocksId) && forestSubtypeIds.includes(toGt.stocksId)) return
       const pairKey = `${fromGt.stocksId}_vers_${toGt.stocksId}`
       headers.push(`${pairKey}_surface_ha_an-1`)
-      if (PAIRS_WITH_CO2E.has(pairKey)) headers.push(`${pairKey}_tCO2e_an-1`)
+      headers.push(`${pairKey}_tCO2e_an-1`)
     })
   })
   return headers
@@ -75,13 +56,10 @@ function generate (outputPath) {
       fluxGroundTypes.forEach((toGt) => {
         if (fromGt.stocksId === toGt.stocksId) return
         if (forestSubtypeIds.includes(fromGt.stocksId) && forestSubtypeIds.includes(toGt.stocksId)) return
-        const pairKey = `${fromGt.stocksId}_vers_${toGt.stocksId}`
         const surface = areas[fromGt.stocksId]?.[toGt.stocksId]?.area
         row.push(surface !== undefined && surface !== null ? surface : 0)
-        if (PAIRS_WITH_CO2E.has(pairKey)) {
-          const co2e = fluxCo2eByGroundType[fromGt.stocksId]?.[toGt.stocksId]
-          row.push(co2e ?? '')
-        }
+        const co2e = fluxCo2eByGroundType[fromGt.stocksId]?.[toGt.stocksId]
+        row.push(co2e ?? '')
       })
     })
     lines.push(row.map(csvValue).join(','))

--- a/scripts/generate-flux2-csv.js
+++ b/scripts/generate-flux2-csv.js
@@ -250,43 +250,14 @@ function generate (outputPath) {
 
   process.stdout.write(`\r  ${total}/${total}\n`)
 
-  // -------------------------------------------------------------------------
-  // Retirer les colonnes entièrement vides (transitions impossibles)
-  // Le fichier de référence DATA ADEME ne contient que les colonnes avec au
-  // moins une valeur non vide.
-  // -------------------------------------------------------------------------
-  const META_COLS = 12 // colonnes de métadonnées toujours conservées
-  const colCount = headers.length
-  const emptyCols = new Set()
-
-  for (let c = META_COLS; c < colCount; c++) {
-    let allEmpty = true
-    for (const row of rows) {
-      if (row[c] !== '' && row[c] !== undefined && row[c] !== null) {
-        allEmpty = false
-        break
-      }
-    }
-    if (allEmpty) emptyCols.add(c)
-  }
-
-  const keepIndices = []
-  for (let c = 0; c < colCount; c++) {
-    if (!emptyCols.has(c)) keepIndices.push(c)
-  }
-
-  if (emptyCols.size > 0) {
-    console.log(`Colonnes vides retirées : ${emptyCols.size} (${colCount} → ${keepIndices.length})`)
-  }
-
-  const lines = [keepIndices.map((c) => headers[c]).join(',')]
+  const lines = [headers.join(',')]
   for (const row of rows) {
-    lines.push(keepIndices.map((c) => csvValue(row[c] ?? '')).join(','))
+    lines.push(row.map((v) => csvValue(v ?? '')).join(','))
   }
 
   fs.writeFileSync(outputPath, lines.join('\n'), 'utf8')
   console.log(`Fichier généré : ${outputPath}`)
-  console.log(`Lignes : ${rows.length} communes  |  Colonnes : ${keepIndices.length}`)
+  console.log(`Lignes : ${rows.length} communes  |  Colonnes : ${headers.length}`)
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/generate-flux2-epci-csv.js
+++ b/scripts/generate-flux2-epci-csv.js
@@ -4,7 +4,8 @@ const path = require('path')
 const { GroundTypes } = require('../calculations/constants')
 const {
   getFluxReferenceValues,
-  cToCo2e
+  cToCo2e,
+  getAnnualSurfaceChange
 } = require('../data/flux')
 const {
   getBiomassCarbonDensity,
@@ -48,33 +49,70 @@ function buildHeaders () {
   return headers
 }
 
-function computeUnitFluxes (location) {
-  const unitFluxMap = new Map()
-  const refFluxes = getFluxReferenceValues(location)
-  refFluxes.forEach((f) => {
-    if (!f.from || !f.to) return
-    const key = `${f.from}||${f.to}||${f.reservoir}`
-    const unitValue = cToCo2e(f.annualFlux * (f.yearsForFlux || 1))
-    if (unitValue !== undefined && unitValue !== null) {
-      unitFluxMap.set(key, unitValue)
-    }
-  })
+// Accumule un échantillon (valeur unitaire d'une commune) pour une paire de
+// changement. La moyenne pondérée n'utilise que les communes ayant un flux et
+// une surface convertie non nuls — c'est exactement ce que fait Aldo pour
+// afficher le flux unitaire à l'échelle EPCI (front/handlers/territory.js :
+// moyenne de annualFluxEquivalent pondérée par la surface, après exclusion des
+// entrées dont value === 0).
+function addSample (acc, key, value, area) {
+  let sample = acc.get(key)
+  if (!sample) {
+    sample = { weightedSum: 0, areaSum: 0, simpleSum: 0, count: 0 }
+    acc.set(key, sample)
+  }
+  if (value !== 0 && area > 0) {
+    sample.weightedSum += value * area
+    sample.areaSum += area
+  }
+  sample.simpleSum += value
+  sample.count += 1
+}
 
-  const areaData = getForestAreaData(location)
+// Calcule les flux unitaires (tCO2e/ha) à l'échelle d'un EPCI en agrégeant ses
+// communes. Pour chaque paire (from, to, réservoir) on fait la moyenne des
+// valeurs communales pondérée par la surface convertie, reproduisant la valeur
+// affichée par Aldo. Lorsqu'aucune commune de l'EPCI n'a de changement pour la
+// paire, on retombe sur une moyenne simple des valeurs unitaires communales
+// (même logique de repli que replaceWithOverride dans le moteur de calcul).
+function computeUnitFluxes (communes) {
+  const acc = new Map()
   const excludeIds = ['haies', 'produits bois']
   const childGroundTypes = GroundTypes.filter((gt) => !gt.children && !excludeIds.includes(gt.stocksId))
 
-  forestSubtypeIds.forEach((fromId) => {
-    const forestBiomassDensities = getForestBiomassCarbonDensities(location, fromId, areaData)
-    const initialBiomassDensity = forestBiomassDensities.live + forestBiomassDensities.dead
-    childGroundTypes.forEach((toGt) => {
-      const toId = toGt.stocksId
-      if (fromId === toId || forestSubtypeIds.includes(toId)) return
-      const annualFlux = getBiomassCarbonDensity(location, toId) - initialBiomassDensity
-      if (annualFlux !== undefined && annualFlux !== null) {
-        unitFluxMap.set(`${fromId}||${toId}||biomasse`, cToCo2e(annualFlux))
-      }
+  communes.forEach((commune) => {
+    const location = { commune }
+
+    const refFluxes = getFluxReferenceValues(location)
+    refFluxes.forEach((f) => {
+      if (!f.from || !f.to) return
+      const unitValue = cToCo2e(f.annualFlux * (f.yearsForFlux || 1))
+      if (unitValue === undefined || unitValue === null) return
+      const area = getAnnualSurfaceChange(location, {}, f.from, f.to) || 0
+      addSample(acc, `${f.from}||${f.to}||${f.reservoir}`, unitValue, area)
     })
+
+    const areaData = getForestAreaData(location)
+    forestSubtypeIds.forEach((fromId) => {
+      const forestBiomassDensities = getForestBiomassCarbonDensities(location, fromId, areaData)
+      const initialBiomassDensity = forestBiomassDensities.live + forestBiomassDensities.dead
+      childGroundTypes.forEach((toGt) => {
+        const toId = toGt.stocksId
+        if (fromId === toId || forestSubtypeIds.includes(toId)) return
+        const annualFlux = getBiomassCarbonDensity(location, toId) - initialBiomassDensity
+        if (annualFlux === undefined || annualFlux === null) return
+        const area = getAnnualSurfaceChange(location, {}, fromId, toId) || 0
+        addSample(acc, `${fromId}||${toId}||biomasse`, cToCo2e(annualFlux), area)
+      })
+    })
+  })
+
+  const unitFluxMap = new Map()
+  acc.forEach((sample, key) => {
+    const value = sample.areaSum > 0
+      ? sample.weightedSum / sample.areaSum
+      : (sample.count ? sample.simpleSum / sample.count : null)
+    if (value !== null) unitFluxMap.set(key, value)
   })
   return unitFluxMap
 }
@@ -98,8 +136,7 @@ function generate (outputPath) {
   epcis.forEach((epci, index) => {
     if (index % 100 === 0) process.stdout.write(`\r  ${index}/${total}`)
     const communes = getCommunesForEpci(epci)
-    const location = { epci, commune: communes[0] }
-    const unitFluxMap = computeUnitFluxes(location)
+    const unitFluxMap = computeUnitFluxes(communes)
     const meta = getEPCIBaseMeta(epci)
 
     const row = [
@@ -124,27 +161,12 @@ function generate (outputPath) {
   })
   process.stdout.write(`\r  ${total}/${total}\n`)
 
-  const metaCols = 12
-  const emptyCols = new Set()
-  for (let c = metaCols; c < headers.length; c++) {
-    let allEmpty = true
-    for (const row of rows) {
-      if (row[c] !== '' && row[c] !== undefined && row[c] !== null) {
-        allEmpty = false
-        break
-      }
-    }
-    if (allEmpty) emptyCols.add(c)
-  }
-
-  const keepIndices = []
-  for (let c = 0; c < headers.length; c++) if (!emptyCols.has(c)) keepIndices.push(c)
-  const lines = [keepIndices.map((c) => headers[c]).join(',')]
-  rows.forEach((row) => lines.push(keepIndices.map((c) => csvValue(row[c] ?? '')).join(',')))
+  const lines = [headers.join(',')]
+  rows.forEach((row) => lines.push(row.map((v) => csvValue(v ?? '')).join(',')))
 
   fs.writeFileSync(outputPath, lines.join('\n'), 'utf8')
   console.log(`Fichier généré : ${outputPath}`)
-  console.log(`Lignes : ${rows.length} EPCI  |  Colonnes : ${keepIndices.length}`)
+  console.log(`Lignes : ${rows.length} EPCI  |  Colonnes : ${headers.length}`)
 }
 
 const outputFile = process.argv[2] || path.join(process.cwd(), 'flux2-epci.csv')


### PR DESCRIPTION
## Contexte

Suite aux derniers commentaires de l'issue #189 (Extractions Data ADEME).

## Problèmes traités

### Flux 2 EPCI — valeurs erronées
Le flux unitaire EPCI était calculé à partir d'**une seule commune** (`communes[0]`), ce qui donnait des valeurs ne correspondant pas à l'affichage Aldo.

→ On agrège désormais **toutes les communes** de l'EPCI en **moyenne pondérée par la surface convertie** (avec repli sur moyenne simple quand l'EPCI n'a aucun changement pour la paire), reproduisant exactement la valeur affichée par Aldo (`front/handlers/territory.js`).

Vérifié sur **CC Faucigny-Glières** :
| Paire (sol) | Avant | Après | Aldo |
|---|---|---|---|
| culture → sols artificiels arborés | 139.33 | **112.66** | 112.7 |
| prairie herbacée → vigne | -161.33 | **-133.47** | ≈ -134 |

### Flux 1 / 2 (commune + EPCI) — colonnes manquantes
« seule la surface est présente » : la colonne `_tCO2e_an-1` n'était émise que pour un sous-ensemble de paires (271 colonnes au lieu de 353).

→ Émission systématique des colonnes co2e et conservation de toutes les colonnes de flux de référence (structure complète : 353 colonnes flux 1, 432 colonnes flux 2).

## Note
Les CSV générés ne sont pas versionnés ; ils sont à régénérer puis à déposer sur le Drive après merge.

Closes #189